### PR TITLE
V2.0.0 API

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ as:
     
      ```elixir
      def deps do
-       [{:base62_uuid, "~> 0.1.0"}]
+       [{:base62_uuid, "~> 2.0.0"}]
      end
      ```
 

--- a/lib/base62_uuid.ex
+++ b/lib/base62_uuid.ex
@@ -24,7 +24,7 @@ defmodule Base62UUID do
       iex> Base62UUID.encode("063cd93e-dd59-43b6-928b-2d00a49087fc")
       {:ok, "0BllEZppLhVt2a9PljPUJ2"}
   """
-  @spec encode(String.t()) :: {:ok, String.t()}
+  @spec encode(String.t()) :: {:ok, String.t()} | {:error, String.t()}
   def encode(uuid) do
     {:ok, encode!(uuid)}
   rescue

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Base62UUID.Mixfile do
   use Mix.Project
 
-  @version "1.2.3"
+  @version "2.0.0"
   @github_url "https://github.com/jclem/base62_uuid"
 
   def project do


### PR DESCRIPTION
This updates the API to use tuples for non-bang functions (`encode/1`/`decode/1`) and raise errors with bang functions (`encode!/1`/`decode!/1`).